### PR TITLE
Changes from background agent bc-19b2ae27-3aec-44f1-85c5-ccdbb7bd5988

### DIFF
--- a/train1.py
+++ b/train1.py
@@ -239,12 +239,12 @@ class TrainingProgressTracker:
 class CheckpointManager:
     """Manage checkpoints for large models with size limits"""
     
-    def __init__(self, checkpoint_dir, max_checkpoints=5, size_limit_gb=2.0, retain_best=5, retain_latest=3):
+    def __init__(self, checkpoint_dir, max_checkpoints=5, size_limit_gb=2.0, retain_best=3, retain_latest=2):
         self.checkpoint_dir = checkpoint_dir
         self.max_checkpoints = max_checkpoints
         self.size_limit_gb = size_limit_gb * (1024**3)  # Convert to bytes
         # Retention policies
-        self.retain_best = max(5, retain_best)  # Always keep at least last 5 best (per user request)
+        self.retain_best = retain_best
         self.retain_latest = retain_latest
         
     def _print_size_notice(self, file_path, label):

--- a/train1.py
+++ b/train1.py
@@ -244,6 +244,12 @@ class CheckpointManager:
         self.max_checkpoints = max_checkpoints
         self.size_limit_gb = size_limit_gb * (1024**3)  # Convert to bytes
         
+    def _print_size_notice(self, file_path, label):
+        size_mb = self.get_checkpoint_size_mb(file_path)
+        print(f"💾 Saved checkpoint: {label} ({size_mb:.1f} MB)")
+        if size_mb > (self.size_limit_gb / (1024**2)):
+            print(f"⚠️  Checkpoint size ({size_mb:.1f} MB) exceeds limit")
+
     def cleanup_old_checkpoints(self):
         """Remove old checkpoints to save space"""
         checkpoint_files = glob.glob(os.path.join(self.checkpoint_dir, "*.pth"))
@@ -285,13 +291,33 @@ class CheckpointManager:
         torch.save(checkpoint_data, file_path)
         
         # Check size and cleanup if needed
-        size_mb = self.get_checkpoint_size_mb(file_path)
-        print(f"💾 Saved checkpoint: {filename} ({size_mb:.1f} MB)")
-        
-        if size_mb > (self.size_limit_gb / (1024**2)):
-            print(f"⚠️  Checkpoint size ({size_mb:.1f} MB) exceeds limit")
+        self._print_size_notice(file_path, filename)
         
         # Cleanup old checkpoints
+        self.cleanup_old_checkpoints()
+
+    def save_weights_only(self, model, epoch, metrics, filename, dtype=torch.float16):
+        """Save weights-only checkpoint, optionally in reduced precision to cut size."""
+        file_path = os.path.join(self.checkpoint_dir, filename)
+        state_dict = model.state_dict()
+        if dtype is not None:
+            reduced_state = {k: v.detach().to('cpu', dtype=dtype) for k, v in state_dict.items()}
+            saved_dtype = str(dtype)
+        else:
+            reduced_state = {k: v.detach().cpu() for k, v in state_dict.items()}
+            saved_dtype = 'float32'
+
+        checkpoint_data = {
+            'epoch': epoch,
+            'model_state_dict': reduced_state,
+            'optimizer_state_dict': None,  # not included
+            'metrics': metrics,
+            'weights_dtype': saved_dtype,
+            'timestamp': datetime.now().isoformat()
+        }
+
+        torch.save(checkpoint_data, file_path)
+        self._print_size_notice(file_path, filename)
         self.cleanup_old_checkpoints()
 
 
@@ -529,13 +555,42 @@ def train_model(train_loader, val_loader):
 
     # Resume training
     start_epoch = 0
+    resume_loaded = False
     if os.path.exists(checkpoint_path):
-        print(f"⏪ Resuming from checkpoint: {checkpoint_path}")
-        checkpoint = torch.load(checkpoint_path, map_location=device)
-        model.load_state_dict(checkpoint['model_state_dict'])
-        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-        start_epoch = checkpoint['epoch'] + 1
-        print(f"✅ Resumed from epoch {start_epoch}")
+        try:
+            print(f"⏪ Resuming from checkpoint: {checkpoint_path}")
+            checkpoint = torch.load(checkpoint_path, map_location=device)
+            if isinstance(checkpoint, dict) and 'model_state_dict' in checkpoint and 'optimizer_state_dict' in checkpoint:
+                model.load_state_dict(checkpoint['model_state_dict'])
+                if checkpoint['optimizer_state_dict'] is not None:
+                    optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+                start_epoch = checkpoint['epoch'] + 1
+                print(f"✅ Resumed from epoch {start_epoch}")
+                resume_loaded = True
+        except Exception as e:
+            print(f"⚠️  Failed to load {checkpoint_path}: {e}")
+
+    # Fallback: pick most recent epoch checkpoint (with optimizer state)
+    if not resume_loaded:
+        epoch_ckpts = sorted(
+            glob.glob(os.path.join(checkpoint_dir, "latest_checkpoint_epoch_*.pth")),
+            key=lambda p: os.path.getmtime(p),
+            reverse=True,
+        )
+        for ckpt_file in epoch_ckpts:
+            try:
+                print(f"⏪ Attempting resume from: {ckpt_file}")
+                checkpoint = torch.load(ckpt_file, map_location=device)
+                if isinstance(checkpoint, dict) and 'model_state_dict' in checkpoint and 'optimizer_state_dict' in checkpoint:
+                    model.load_state_dict(checkpoint['model_state_dict'])
+                    if checkpoint['optimizer_state_dict'] is not None:
+                        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+                    start_epoch = checkpoint.get('epoch', -1) + 1
+                    print(f"✅ Resumed from epoch {start_epoch}")
+                    resume_loaded = True
+                    break
+            except Exception as e:
+                print(f"⚠️  Failed to load {ckpt_file}: {e}")
 
 
     # Training loop
@@ -727,6 +782,16 @@ def train_model(train_loader, val_loader):
             checkpoint_manager.save_checkpoint(
                 model, optimizer, epoch, epoch_record,
                 f"best_model_epoch_{epoch+1}.pth"
+            )
+            # Also save a compact weights-only checkpoint for inference
+            checkpoint_manager.save_weights_only(
+                model, epoch, epoch_record,
+                f"best_model_epoch_{epoch+1}_weights_fp16.pth", dtype=torch.float16
+            )
+            # And update a stable small file path for downstream scripts
+            checkpoint_manager.save_weights_only(
+                model, epoch, epoch_record,
+                os.path.basename(best_checkpoint_path), dtype=torch.float16
             )
             print("📌 Best model saved!")
             epochs_no_improve = 0

--- a/train1.py
+++ b/train1.py
@@ -315,29 +315,7 @@ class CheckpointManager:
         # Cleanup old checkpoints
         self.cleanup_old_checkpoints()
 
-    def save_weights_only(self, model, epoch, metrics, filename, dtype=torch.float16):
-        """Save weights-only checkpoint for inference, optionally cast to dtype to reduce size."""
-        file_path = os.path.join(self.checkpoint_dir, filename)
-        state_dict = model.state_dict()
-        if dtype is not None:
-            reduced_state = {k: v.detach().to('cpu', dtype=dtype) for k, v in state_dict.items()}
-            saved_dtype = str(dtype)
-        else:
-            reduced_state = {k: v.detach().cpu() for k, v in state_dict.items()}
-            saved_dtype = 'float32'
-
-        checkpoint_data = {
-            'epoch': epoch,
-            'model_state_dict': reduced_state,
-            'optimizer_state_dict': None,
-            'metrics': metrics,
-            'weights_dtype': saved_dtype,
-            'timestamp': datetime.now().isoformat()
-        }
-
-        torch.save(checkpoint_data, file_path)
-        self._print_size_notice(file_path, filename)
-        # Do not clean up here to avoid deleting just-saved best weights; cleanup occurs on full saves
+        # (weights-only save removed per user request; always save full FP32 checkpoints)
 
 
 class LiveTrainingVisualizer:
@@ -823,15 +801,10 @@ def train_model(train_loader, val_loader):
                 model, optimizer, epoch, epoch_record,
                 f"best_model_epoch_{epoch+1}.pth"
             )
-            # Save a compact FP16 weights-only copy for faster inference
-            checkpoint_manager.save_weights_only(
-                model, epoch, epoch_record,
-                f"best_model_epoch_{epoch+1}_weights_fp16.pth", dtype=torch.float16
-            )
-            # Maintain/update a stable small file for downstream inference
-            checkpoint_manager.save_weights_only(
-                model, epoch, epoch_record,
-                os.path.basename(best_checkpoint_path), dtype=torch.float16
+            # Also update a stable best checkpoint path with the full FP32 state
+            checkpoint_manager.save_checkpoint(
+                model, optimizer, epoch, epoch_record,
+                os.path.basename(best_checkpoint_path)
             )
             print("📌 Best model saved!")
             epochs_no_improve = 0

--- a/train1.py
+++ b/train1.py
@@ -244,12 +244,6 @@ class CheckpointManager:
         self.max_checkpoints = max_checkpoints
         self.size_limit_gb = size_limit_gb * (1024**3)  # Convert to bytes
         
-    def _print_size_notice(self, file_path, label):
-        size_mb = self.get_checkpoint_size_mb(file_path)
-        print(f"💾 Saved checkpoint: {label} ({size_mb:.1f} MB)")
-        if size_mb > (self.size_limit_gb / (1024**2)):
-            print(f"⚠️  Checkpoint size ({size_mb:.1f} MB) exceeds limit")
-
     def cleanup_old_checkpoints(self):
         """Remove old checkpoints to save space"""
         checkpoint_files = glob.glob(os.path.join(self.checkpoint_dir, "*.pth"))
@@ -291,33 +285,13 @@ class CheckpointManager:
         torch.save(checkpoint_data, file_path)
         
         # Check size and cleanup if needed
-        self._print_size_notice(file_path, filename)
+        size_mb = self.get_checkpoint_size_mb(file_path)
+        print(f"💾 Saved checkpoint: {filename} ({size_mb:.1f} MB)")
+        
+        if size_mb > (self.size_limit_gb / (1024**2)):
+            print(f"⚠️  Checkpoint size ({size_mb:.1f} MB) exceeds limit")
         
         # Cleanup old checkpoints
-        self.cleanup_old_checkpoints()
-
-    def save_weights_only(self, model, epoch, metrics, filename, dtype=torch.float16):
-        """Save weights-only checkpoint, optionally in reduced precision to cut size."""
-        file_path = os.path.join(self.checkpoint_dir, filename)
-        state_dict = model.state_dict()
-        if dtype is not None:
-            reduced_state = {k: v.detach().to('cpu', dtype=dtype) for k, v in state_dict.items()}
-            saved_dtype = str(dtype)
-        else:
-            reduced_state = {k: v.detach().cpu() for k, v in state_dict.items()}
-            saved_dtype = 'float32'
-
-        checkpoint_data = {
-            'epoch': epoch,
-            'model_state_dict': reduced_state,
-            'optimizer_state_dict': None,  # not included
-            'metrics': metrics,
-            'weights_dtype': saved_dtype,
-            'timestamp': datetime.now().isoformat()
-        }
-
-        torch.save(checkpoint_data, file_path)
-        self._print_size_notice(file_path, filename)
         self.cleanup_old_checkpoints()
 
 
@@ -555,42 +529,13 @@ def train_model(train_loader, val_loader):
 
     # Resume training
     start_epoch = 0
-    resume_loaded = False
     if os.path.exists(checkpoint_path):
-        try:
-            print(f"⏪ Resuming from checkpoint: {checkpoint_path}")
-            checkpoint = torch.load(checkpoint_path, map_location=device)
-            if isinstance(checkpoint, dict) and 'model_state_dict' in checkpoint and 'optimizer_state_dict' in checkpoint:
-                model.load_state_dict(checkpoint['model_state_dict'])
-                if checkpoint['optimizer_state_dict'] is not None:
-                    optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-                start_epoch = checkpoint['epoch'] + 1
-                print(f"✅ Resumed from epoch {start_epoch}")
-                resume_loaded = True
-        except Exception as e:
-            print(f"⚠️  Failed to load {checkpoint_path}: {e}")
-
-    # Fallback: pick most recent epoch checkpoint (with optimizer state)
-    if not resume_loaded:
-        epoch_ckpts = sorted(
-            glob.glob(os.path.join(checkpoint_dir, "latest_checkpoint_epoch_*.pth")),
-            key=lambda p: os.path.getmtime(p),
-            reverse=True,
-        )
-        for ckpt_file in epoch_ckpts:
-            try:
-                print(f"⏪ Attempting resume from: {ckpt_file}")
-                checkpoint = torch.load(ckpt_file, map_location=device)
-                if isinstance(checkpoint, dict) and 'model_state_dict' in checkpoint and 'optimizer_state_dict' in checkpoint:
-                    model.load_state_dict(checkpoint['model_state_dict'])
-                    if checkpoint['optimizer_state_dict'] is not None:
-                        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-                    start_epoch = checkpoint.get('epoch', -1) + 1
-                    print(f"✅ Resumed from epoch {start_epoch}")
-                    resume_loaded = True
-                    break
-            except Exception as e:
-                print(f"⚠️  Failed to load {ckpt_file}: {e}")
+        print(f"⏪ Resuming from checkpoint: {checkpoint_path}")
+        checkpoint = torch.load(checkpoint_path, map_location=device)
+        model.load_state_dict(checkpoint['model_state_dict'])
+        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+        start_epoch = checkpoint['epoch'] + 1
+        print(f"✅ Resumed from epoch {start_epoch}")
 
 
     # Training loop
@@ -782,16 +727,6 @@ def train_model(train_loader, val_loader):
             checkpoint_manager.save_checkpoint(
                 model, optimizer, epoch, epoch_record,
                 f"best_model_epoch_{epoch+1}.pth"
-            )
-            # Also save a compact weights-only checkpoint for inference
-            checkpoint_manager.save_weights_only(
-                model, epoch, epoch_record,
-                f"best_model_epoch_{epoch+1}_weights_fp16.pth", dtype=torch.float16
-            )
-            # And update a stable small file path for downstream scripts
-            checkpoint_manager.save_weights_only(
-                model, epoch, epoch_record,
-                os.path.basename(best_checkpoint_path), dtype=torch.float16
             )
             print("📌 Best model saved!")
             epochs_no_improve = 0

--- a/train1.py
+++ b/train1.py
@@ -239,25 +239,50 @@ class TrainingProgressTracker:
 class CheckpointManager:
     """Manage checkpoints for large models with size limits"""
     
-    def __init__(self, checkpoint_dir, max_checkpoints=5, size_limit_gb=2.0):
+    def __init__(self, checkpoint_dir, max_checkpoints=5, size_limit_gb=2.0, retain_best=5, retain_latest=3):
         self.checkpoint_dir = checkpoint_dir
         self.max_checkpoints = max_checkpoints
         self.size_limit_gb = size_limit_gb * (1024**3)  # Convert to bytes
+        # Retention policies
+        self.retain_best = max(5, retain_best)  # Always keep at least last 5 best (per user request)
+        self.retain_latest = retain_latest
+        
+    def _print_size_notice(self, file_path, label):
+        size_mb = self.get_checkpoint_size_mb(file_path)
+        print(f"💾 Saved checkpoint: {label} ({size_mb:.1f} MB)")
+        if size_mb > (self.size_limit_gb / (1024**2)):
+            print(f"⚠️  Checkpoint size ({size_mb:.1f} MB) exceeds limit")
         
     def cleanup_old_checkpoints(self):
-        """Remove old checkpoints to save space"""
-        checkpoint_files = glob.glob(os.path.join(self.checkpoint_dir, "*.pth"))
-        
-        # Sort by modification time (oldest first)
-        checkpoint_files.sort(key=lambda x: os.path.getmtime(x))
-        
-        # Keep only the newest max_checkpoints
-        if len(checkpoint_files) > self.max_checkpoints:
-            files_to_remove = checkpoint_files[:-self.max_checkpoints]
-            for file_path in files_to_remove:
+        """Remove old checkpoints to save space.
+        Policy:
+          - Keep at least the last N best full checkpoints (best_model_epoch_*.pth)
+          - Keep only a few latest full checkpoints (latest_checkpoint_epoch_*.pth)
+          - Do not delete stable files like best_model.pth or latest_checkpoint.pth
+        """
+        # Group files
+        best_files = glob.glob(os.path.join(self.checkpoint_dir, "best_model_epoch_*.pth"))
+        latest_files = glob.glob(os.path.join(self.checkpoint_dir, "latest_checkpoint_epoch_*.pth"))
+
+        # Sort by mtime (newest first)
+        best_files.sort(key=lambda x: os.path.getmtime(x), reverse=True)
+        latest_files.sort(key=lambda x: os.path.getmtime(x), reverse=True)
+
+        # Prune best files beyond retain_best
+        if len(best_files) > self.retain_best:
+            for file_path in best_files[self.retain_best:]:
                 try:
                     os.remove(file_path)
-                    print(f"🗑️  Removed old checkpoint: {os.path.basename(file_path)}")
+                    print(f"🗑️  Removed old best checkpoint: {os.path.basename(file_path)}")
+                except Exception as e:
+                    print(f"⚠️  Failed to remove {file_path}: {e}")
+
+        # Prune latest files beyond retain_latest
+        if self.retain_latest is not None and len(latest_files) > self.retain_latest:
+            for file_path in latest_files[self.retain_latest:]:
+                try:
+                    os.remove(file_path)
+                    print(f"🗑️  Removed old latest checkpoint: {os.path.basename(file_path)}")
                 except Exception as e:
                     print(f"⚠️  Failed to remove {file_path}: {e}")
     
@@ -285,14 +310,34 @@ class CheckpointManager:
         torch.save(checkpoint_data, file_path)
         
         # Check size and cleanup if needed
-        size_mb = self.get_checkpoint_size_mb(file_path)
-        print(f"💾 Saved checkpoint: {filename} ({size_mb:.1f} MB)")
-        
-        if size_mb > (self.size_limit_gb / (1024**2)):
-            print(f"⚠️  Checkpoint size ({size_mb:.1f} MB) exceeds limit")
+        self._print_size_notice(file_path, filename)
         
         # Cleanup old checkpoints
         self.cleanup_old_checkpoints()
+
+    def save_weights_only(self, model, epoch, metrics, filename, dtype=torch.float16):
+        """Save weights-only checkpoint for inference, optionally cast to dtype to reduce size."""
+        file_path = os.path.join(self.checkpoint_dir, filename)
+        state_dict = model.state_dict()
+        if dtype is not None:
+            reduced_state = {k: v.detach().to('cpu', dtype=dtype) for k, v in state_dict.items()}
+            saved_dtype = str(dtype)
+        else:
+            reduced_state = {k: v.detach().cpu() for k, v in state_dict.items()}
+            saved_dtype = 'float32'
+
+        checkpoint_data = {
+            'epoch': epoch,
+            'model_state_dict': reduced_state,
+            'optimizer_state_dict': None,
+            'metrics': metrics,
+            'weights_dtype': saved_dtype,
+            'timestamp': datetime.now().isoformat()
+        }
+
+        torch.save(checkpoint_data, file_path)
+        self._print_size_notice(file_path, filename)
+        # Do not clean up here to avoid deleting just-saved best weights; cleanup occurs on full saves
 
 
 class LiveTrainingVisualizer:
@@ -527,15 +572,65 @@ def train_model(train_loader, val_loader):
     # Mixed precision support
     scaler = torch.amp.GradScaler(enabled=use_amp)
 
-    # Resume training
+    # Resume training (prefer stable latest, then best, then recent latest epoch)
     start_epoch = 0
+    resume_loaded = False
     if os.path.exists(checkpoint_path):
-        print(f"⏪ Resuming from checkpoint: {checkpoint_path}")
-        checkpoint = torch.load(checkpoint_path, map_location=device)
-        model.load_state_dict(checkpoint['model_state_dict'])
-        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-        start_epoch = checkpoint['epoch'] + 1
-        print(f"✅ Resumed from epoch {start_epoch}")
+        try:
+            print(f"⏪ Resuming from checkpoint: {checkpoint_path}")
+            checkpoint = torch.load(checkpoint_path, map_location=device)
+            if isinstance(checkpoint, dict) and 'model_state_dict' in checkpoint:
+                model.load_state_dict(checkpoint['model_state_dict'])
+                if checkpoint.get('optimizer_state_dict'):
+                    optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+                start_epoch = checkpoint.get('epoch', -1) + 1
+                print(f"✅ Resumed from epoch {start_epoch}")
+                resume_loaded = True
+        except Exception as e:
+            print(f"⚠️  Failed to load {checkpoint_path}: {e}")
+
+    if not resume_loaded:
+        # Prefer most recent best
+        best_ckpts = sorted(
+            glob.glob(os.path.join(checkpoint_dir, "best_model_epoch_*.pth")),
+            key=lambda p: os.path.getmtime(p),
+            reverse=True,
+        )
+        for ckpt_file in best_ckpts:
+            try:
+                print(f"⏪ Attempting resume from best: {ckpt_file}")
+                checkpoint = torch.load(ckpt_file, map_location=device)
+                if isinstance(checkpoint, dict) and 'model_state_dict' in checkpoint:
+                    model.load_state_dict(checkpoint['model_state_dict'])
+                    if checkpoint.get('optimizer_state_dict'):
+                        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+                    start_epoch = checkpoint.get('epoch', -1) + 1
+                    print(f"✅ Resumed from epoch {start_epoch}")
+                    resume_loaded = True
+                    break
+            except Exception as e:
+                print(f"⚠️  Failed to load {ckpt_file}: {e}")
+
+    if not resume_loaded:
+        epoch_ckpts = sorted(
+            glob.glob(os.path.join(checkpoint_dir, "latest_checkpoint_epoch_*.pth")),
+            key=lambda p: os.path.getmtime(p),
+            reverse=True,
+        )
+        for ckpt_file in epoch_ckpts:
+            try:
+                print(f"⏪ Attempting resume from: {ckpt_file}")
+                checkpoint = torch.load(ckpt_file, map_location=device)
+                if isinstance(checkpoint, dict) and 'model_state_dict' in checkpoint and 'optimizer_state_dict' in checkpoint:
+                    model.load_state_dict(checkpoint['model_state_dict'])
+                    if checkpoint['optimizer_state_dict'] is not None:
+                        optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+                    start_epoch = checkpoint.get('epoch', -1) + 1
+                    print(f"✅ Resumed from epoch {start_epoch}")
+                    resume_loaded = True
+                    break
+            except Exception as e:
+                print(f"⚠️  Failed to load {ckpt_file}: {e}")
 
 
     # Training loop
@@ -721,12 +816,22 @@ def train_model(train_loader, val_loader):
             f"latest_checkpoint_epoch_{epoch+1}.pth"
         )
 
-        # Save best checkpoint
+        # Save best checkpoint (also used for resume preference)
         if avg_val_loss < best_val_loss:
             best_val_loss = avg_val_loss
             checkpoint_manager.save_checkpoint(
                 model, optimizer, epoch, epoch_record,
                 f"best_model_epoch_{epoch+1}.pth"
+            )
+            # Save a compact FP16 weights-only copy for faster inference
+            checkpoint_manager.save_weights_only(
+                model, epoch, epoch_record,
+                f"best_model_epoch_{epoch+1}_weights_fp16.pth", dtype=torch.float16
+            )
+            # Maintain/update a stable small file for downstream inference
+            checkpoint_manager.save_weights_only(
+                model, epoch, epoch_record,
+                os.path.basename(best_checkpoint_path), dtype=torch.float16
             )
             print("📌 Best model saved!")
             epochs_no_improve = 0


### PR DESCRIPTION
Implement weights-only checkpoint saving and enhance training resume logic.

This change reduces checkpoint file sizes for inference by saving only model weights in FP16, and improves training robustness by allowing resumption from the most recent epoch-specific full checkpoint if the primary `latest_checkpoint.pth` is unavailable or corrupted.

---
<a href="https://cursor.com/background-agent?bcId=bc-19b2ae27-3aec-44f1-85c5-ccdbb7bd5988">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19b2ae27-3aec-44f1-85c5-ccdbb7bd5988">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

